### PR TITLE
Clear events at beginning of `touch_event`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piston-button_controller"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["controller", "button", "piston"]
 description = "A Piston library for handling button state and events"
@@ -19,3 +19,4 @@ pistoncore-input = "0.17.0"
 
 [dev-dependencies]
 piston_window = "0.63.0"
+pistoncore-sdl2_window = "0.41.0"

--- a/examples/button_touch_test.rs
+++ b/examples/button_touch_test.rs
@@ -1,0 +1,40 @@
+extern crate piston_window;
+extern crate sdl2_window;
+extern crate button_controller;
+
+use sdl2_window::Sdl2Window;
+use piston_window::*;
+use button_controller::{ButtonController, ButtonEvent, ButtonState};
+
+fn main() {
+    let mut window: PistonWindow<Sdl2Window> = WindowSettings::new("touch button", [300; 2])
+        .exit_on_esc(true)
+        .build()
+        .unwrap();
+
+    let mut click_me = ButtonController::new();
+    let click_me_layout = [10.0, 60.0, 280.0, 180.0];
+    while let Some(e) = window.next() {
+        click_me.touch_event(click_me_layout, math::identity(), window.size(), &e);
+        for e in &click_me.events {
+            println!("{}", match *e {
+                ButtonEvent::Click => "Click",
+                ButtonEvent::MouseEnter => "MouseEnter",
+                ButtonEvent::MouseLeave => "MouseLeave",
+                ButtonEvent::Press => "Press",
+                ButtonEvent::Cancel => "Cancel",
+            })
+        }
+
+        window.draw_2d(&e, |c, g| {
+            clear([1.0; 4], g);
+            let color = match click_me.state(0.2) {
+                ButtonState::Inactive => [0.6, 0.6, 0.6, 1.0],
+                ButtonState::Hover => [0.4, 0.4, 0.4, 1.0],
+                ButtonState::Press => [0.1, 0.1, 0.1, 1.0],
+                ButtonState::Cancel => [0.3, 0.2, 0.2, 1.0],
+            };
+            rectangle(color, click_me_layout, c.transform, g);
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ impl ButtonController {
         use input::Touch;
         use math::is_inside;
 
+        self.events.clear();
         let window_size = window_size.into();
         if let Some(args) = e.touch_args() {
             let pos = args.position();


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/button_controller/issues/4

- Bumped to 0.1.2
- Added “examples/button_touch_test”